### PR TITLE
SSP-5918 fix tiptob only hide table menu for first editor

### DIFF
--- a/src/plugins/Table/TableExtension.ts
+++ b/src/plugins/Table/TableExtension.ts
@@ -5,8 +5,8 @@ import { bubbleMenuAutoUpdate, getBubbleMenuElement } from "../../utils/bubble-m
 
 const tableBubbleMenuPluginKey = new PluginKey("tableBubbleMenu");
 
-export function getBubbleMenuExtension(getEditor: () => Editor): Extension {
-  const element = getBubbleMenuElement("tiptob-table-bubble-menu");
+export function getBubbleMenuExtension(getEditor: () => Editor, customElement?: HTMLElement | null): Extension {
+  const element = customElement ? getBubbleMenuElement(customElement) : getBubbleMenuElement("tiptob-table-bubble-menu");
 
   return BubbleMenu.extend({ name: "tableBubbleMenu" }).configure({
     pluginKey: tableBubbleMenuPluginKey,

--- a/src/plugins/Table/TableExtension.ts
+++ b/src/plugins/Table/TableExtension.ts
@@ -5,7 +5,7 @@ import { bubbleMenuAutoUpdate, getBubbleMenuElement } from "../../utils/bubble-m
 
 const tableBubbleMenuPluginKey = new PluginKey("tableBubbleMenu");
 
-export function getBubbleMenuExtension(getEditor: () => Editor, customElement?: HTMLElement | null): Extension {
+export function getBubbleMenuExtension(getEditor: () => Editor, customElement?: HTMLElement): Extension {
   const element = customElement ? getBubbleMenuElement(customElement) : getBubbleMenuElement("tiptob-table-bubble-menu");
 
   return BubbleMenu.extend({ name: "tableBubbleMenu" }).configure({

--- a/src/utils/bubble-menu.ts
+++ b/src/utils/bubble-menu.ts
@@ -5,8 +5,10 @@ import type { PluginKey } from "@tiptap/pm/state";
 // The v3 bubble menu plugin only hides the element on a show→hide transition.
 // Until the first show, the element stays visible in normal flow where the
 // host placed it, so it must start out hidden and out of flow.
-export function getBubbleMenuElement(selector: string): HTMLElement | null {
-  const element = document.querySelector<HTMLElement>(selector);
+export function getBubbleMenuElement(selectorOrElement: string | HTMLElement): HTMLElement | null {
+  const element = typeof selectorOrElement === "string"
+    ? document.querySelector<HTMLElement>(selectorOrElement)
+    : selectorOrElement;
   if (element) {
     element.style.visibility = "hidden";
     element.style.position = "fixed";


### PR DESCRIPTION
When rendering multiple editors on the same page (e.g., Customer, Technician, etc.), the table bubble menu (the toolbar at the bottom) was only hidden for the first editor. For all subsequent editors, the menu remained visible in the normal layout flow.
<img width="1024" height="544" alt="image" src="https://github.com/user-attachments/assets/5ad62998-a9e2-485c-8f0a-b131e10271fb" />


1. Why it Happened (Root Cause)

- Global Selector Lookup: In the Tiptob library's TableExtension.ts, the extension resolved its bubble menu element using document.querySelector("tiptob-table-bubble-menu").

- First Element Matching: Since querySelector returns the first matching element in the entire DOM, all editor instances (first, second, third) resolved to the first editor's bubble menu element.

- Leftover Elements: The first editor's menu element was hidden and bound successfully, but the bubble menus for the subsequent editors were never selected by the extensions, never got their visibility: hidden and position: fixed styles applied, and thus remained visible in the page flow.

2. Summary of Changes Applied
Changes in the Tiptob Library:
- src/utils/bubble-menu.ts: Modified getBubbleMenuElement to accept either a selector string or an HTMLElement reference directly.
- src/plugins/Table/TableExtension.ts: Added an optional second argument customElement to getBubbleMenuExtension to bypass the global querySelector search when an explicit DOM reference is supplied.